### PR TITLE
updated `int(` to `parse(Int,`

### DIFF
--- a/examples/Julia/wuclient.jl
+++ b/examples/Julia/wuclient.jl
@@ -15,7 +15,7 @@ println("Collecting updates from weather server...")
 connect(socket, "tcp://localhost:5556")
 
 # Subscribe to zipcode, default is NYC, 10001
-zip_filter = length(ARGS) > 0 ? int(ARGS[1]) : 10001
+zip_filter = length(ARGS) > 0 ? parse(Int,ARGS[1]) : 10001
 
 subscribe(socket, string(zip_filter))
 


### PR DESCRIPTION
The current example gives this error when you pass an argument: 

ERROR: LoadError: UndefVarError: `int` not defined

This is because you can't directly cast `String`s as `Int`s. I've updated to code to appropriately call `parse` to do the conversion.